### PR TITLE
120 id restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examma-ray",
-  "version": "1.0.115",
+  "version": "1.0.116",
   "description": "## Setup",
   "main": "dist/examma-ray.js",
   "types": "dist/examma-ray.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examma-ray",
-  "version": "1.0.116",
+  "version": "1.0.117",
   "description": "## Setup",
   "main": "dist/examma-ray.js",
   "types": "dist/examma-ray.d.ts",

--- a/src/exams.ts
+++ b/src/exams.ts
@@ -6,7 +6,7 @@ import { mk2html, mk2html_unwrapped } from './render';
 import { maxPrecisionString, renderFixedPrecisionBadge, renderPointsWorthBadge, renderScoreBadge, renderUngradedBadge } from "./ui_components";
 import { Exception, GraderMap } from './ExamGrader';
 import { QuestionGrader, GradingResult } from './QuestionGrader';
-import { QuestionSpecification, SkinGenerator, SectionSpecification, QuestionChooser, SectionChooser, ExamSpecification, DEFAULT_SKIN_GENERATOR } from './specification';
+import { QuestionSpecification, SkinGenerator, SectionSpecification, QuestionChooser, SectionChooser, ExamSpecification, DEFAULT_SKIN_GENERATOR, isValidID } from './specification';
 import { DEFAULT_SKIN, QuestionSkin } from './skins';
 import { ExamManifest } from './submissions';
 import { sum } from 'simple-statistics';
@@ -47,6 +47,7 @@ export class Question<QT extends ResponseKind = ResponseKind> {
 
   public constructor (spec: QuestionSpecification<QT>) {
     this.spec = spec;
+    assert(isValidID(spec.id), `Invalid question ID: ${spec.id}`);
     this.question_id = spec.id;
     this.tags = spec.tags ?? [];
     this.mk_description = spec.mk_description;
@@ -278,6 +279,7 @@ export class Section {
 
   public constructor (spec: SectionSpecification) {
     this.spec = spec;
+    assert(isValidID(spec.id), `Invalid section ID: ${spec.id}`);
     this.section_id = spec.id;
     this.title = spec.title;
     this.mk_description = spec.mk_description;
@@ -442,6 +444,7 @@ export class AssignedExam {
     this.uuid = uuid;
     this.exam = exam;
     this.student = student;
+    assert(isValidID(student.uniqname), `Invalid student uniqname: ${student.uniqname}`);
     this.assignedSections = assignedSections;
     this.assignedQuestions = assignedSections.flatMap(s => s.assignedQuestions);
     this.assignedQuestions.forEach(q => this.assignedQuestionById[q.question.question_id] = q);
@@ -667,6 +670,7 @@ export class Exam {
   public readonly enable_regrades: boolean;
 
   public constructor(spec: ExamSpecification) {
+    assert(isValidID(spec.id), `Invalid exam ID: ${spec.id}`);
     this.exam_id = spec.id;
     this.title = spec.title;
     this.html_instructions = mk2html(spec.mk_intructions);

--- a/src/specification.ts
+++ b/src/specification.ts
@@ -6,6 +6,10 @@ import { ResponseSpecification, SubmissionType } from "./response/responses";
 import { DEFAULT_SKIN, QuestionSkin } from "./skins";
 import { assert } from "./util";
 
+export function isValidID(id: string) {
+  return /^[a-zA-Z][a-zA-Z0-9_\-]$/.test(id);
+}
+
 export const CHOOSE_ALL = Symbol("choose_all");
 
 export type ExamSpecification = {

--- a/src/specification.ts
+++ b/src/specification.ts
@@ -7,7 +7,7 @@ import { DEFAULT_SKIN, QuestionSkin } from "./skins";
 import { assert } from "./util";
 
 export function isValidID(id: string) {
-  return /^[a-zA-Z][a-zA-Z0-9_\-]$/.test(id);
+  return /^[a-zA-Z][a-zA-Z0-9_\-]*$/.test(id);
 }
 
 export const CHOOSE_ALL = Symbol("choose_all");

--- a/src/specification.ts
+++ b/src/specification.ts
@@ -138,6 +138,7 @@ export function RANDOM_SKIN(skins: readonly QuestionSkin[]) {
 
 export function CUSTOMIZE(spec: QuestionSpecification, customizations: Partial<Exclude<QuestionSpecification, "response">>) : QuestionSpecification;
 export function CUSTOMIZE(spec: SectionSpecification, customizations: Partial<Exclude<SectionSpecification, "response">>) : SectionSpecification;
-export function CUSTOMIZE(spec: QuestionSpecification | SectionSpecification, customizations: Partial<Exclude<QuestionSpecification | SectionSpecification, "response">>) : QuestionSpecification | SectionSpecification {
+export function CUSTOMIZE(spec: ExamSpecification, customizations: Partial<Exclude<ExamSpecification, "response">>) : ExamSpecification;
+export function CUSTOMIZE(spec: QuestionSpecification | SectionSpecification | ExamSpecification, customizations: Partial<Exclude<QuestionSpecification | SectionSpecification | ExamSpecification, "response">>) : QuestionSpecification | SectionSpecification | ExamSpecification {
   return Object.assign({}, spec, customizations);
 }

--- a/test/assigned_exam.spec.ts
+++ b/test/assigned_exam.spec.ts
@@ -1,0 +1,25 @@
+import 'mocha';
+import { expect } from 'chai';
+import { AssignedExam, Exam } from '../src/exams';
+import { CUSTOMIZE, ExamSpecification, QuestionSpecification, SectionSpecification } from '../src/specification';
+import { MC_Basic } from './question.spec';
+import { INVALID_IDS, VALID_IDS } from './common.spec';
+import { Section_MC_Basic } from './section.spec';
+import { Exam_MC_Basic } from './exam.spec';
+
+
+describe('Exam Specification', () => {
+
+  it('Allows Valid Exam IDs', () => {
+    VALID_IDS.forEach(
+      id => expect(() => new AssignedExam("uuid", new Exam(Exam_MC_Basic), {name: "student", uniqname: id}, [], false)).not.to.throw()
+    );
+  });
+
+  it('Prohibits Invalid Exam IDs', () => {
+    INVALID_IDS.forEach(
+      id => expect(() => new AssignedExam("uuid", new Exam(Exam_MC_Basic), {name: "student", uniqname: id}, [], false)).to.throw()
+    );
+  });
+
+});

--- a/test/common.spec.ts
+++ b/test/common.spec.ts
@@ -2,6 +2,26 @@ import 'mocha';
 import { expect } from 'chai';
 import { ExamSubmission, fillManifest } from '../src/submissions';
 
+export const VALID_IDS = [
+  "blah",
+  "question_id1",
+  "aAzZ09-_",
+  "a",
+  "a_-_-_-a",
+];
+
+export const INVALID_IDS = [
+  "1question_id",
+  "",
+  "1",
+  "-_alsdf",
+  "_sflaalsdf",
+  "aslkdhf+=",
+  "_______",
+  "++++",
+  "0azaz",
+];
+
 const manifest : ExamSubmission = {
   "uuid": "exam_uuid_1",
   "exam_id": "eecs280sp20test",

--- a/test/exam.spec.ts
+++ b/test/exam.spec.ts
@@ -1,0 +1,33 @@
+import 'mocha';
+import { expect } from 'chai';
+import { ExamSubmission, fillManifest } from '../src/submissions';
+import { Exam, Question, Section } from '../src/exams';
+import { CUSTOMIZE, ExamSpecification, QuestionSpecification, SectionSpecification } from '../src/specification';
+import { MC_Basic } from './question.spec';
+import { INVALID_IDS, VALID_IDS } from './common.spec';
+import { Section_MC_Basic } from './section.spec';
+
+export const Exam_MC_Basic : ExamSpecification = {
+  id: "exam_id",
+  title: "[exam title]",
+  mk_intructions: "[instructions]",
+  sections: [Section_MC_Basic]
+};
+
+
+
+describe('Exam Specification', () => {
+
+  it('Allows Valid Exam IDs', () => {
+    VALID_IDS.forEach(
+      id => expect(() => new Exam(CUSTOMIZE(Exam_MC_Basic, {id: id}))).not.to.throw()
+    );
+  });
+
+  it('Prohibits Invalid Exam IDs', () => {
+    INVALID_IDS.forEach(
+      id => expect(() => new Exam(CUSTOMIZE(Exam_MC_Basic, {id: id}))).to.throw()
+    );
+  });
+
+});

--- a/test/question.spec.ts
+++ b/test/question.spec.ts
@@ -3,8 +3,9 @@ import { expect } from 'chai';
 import { ExamSubmission, fillManifest } from '../src/submissions';
 import { Question } from '../src/exams';
 import { CUSTOMIZE, QuestionSpecification } from '../src/specification';
+import { INVALID_IDS, VALID_IDS } from './common.spec';
 
-const MC_Basic : QuestionSpecification = {
+export const MC_Basic : QuestionSpecification = {
   id: "question_id",
   points: 1,
   mk_description: "[description]",
@@ -13,27 +14,20 @@ const MC_Basic : QuestionSpecification = {
     choices: ["choice1", "choice2", "choice3", "choice4", "choice5"],
     multiple: false
   }
-}
+};
 
 describe('Question Specification', () => {
 
   it('Allows Valid Question IDs', () => {
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "question_id1"}))).not.to.throw();
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "aAzZ09-_-"}))).not.to.throw();
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "a"}))).not.to.throw();
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "a_-_-_-a"}))).not.to.throw();
+    VALID_IDS.forEach(
+      id => expect(() => new Question(CUSTOMIZE(MC_Basic, {id: id}))).not.to.throw()
+    );
   });
 
   it('Prohibits Invalid Question IDs', () => {
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "1question_id"}))).to.throw(Error);
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: ""}))).to.throw(Error);
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "1"}))).to.throw(Error);
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "-_alsdf"}))).to.throw(Error);
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "_sflaalsdf"}))).to.throw(Error);
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "aslkdhf+="}))).to.throw(Error);
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "_______"}))).to.throw(Error);
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "++++"}))).to.throw(Error);
-    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "0azaz"}))).to.throw(Error);
+    INVALID_IDS.forEach(
+      id => expect(() => new Question(CUSTOMIZE(MC_Basic, {id: id}))).to.throw()
+    );
   });
 
 });

--- a/test/question.spec.ts
+++ b/test/question.spec.ts
@@ -1,0 +1,39 @@
+import 'mocha';
+import { expect } from 'chai';
+import { ExamSubmission, fillManifest } from '../src/submissions';
+import { Question } from '../src/exams';
+import { CUSTOMIZE, QuestionSpecification } from '../src/specification';
+
+const MC_Basic : QuestionSpecification = {
+  id: "question_id",
+  points: 1,
+  mk_description: "[description]",
+  response: {
+    kind: "multiple_choice",
+    choices: ["choice1", "choice2", "choice3", "choice4", "choice5"],
+    multiple: false
+  }
+}
+
+describe('Question Specification', () => {
+
+  it('Allows Valid Question IDs', () => {
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "question_id1"}))).not.to.throw();
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "aAzZ09-_-"}))).not.to.throw();
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "a"}))).not.to.throw();
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "a_-_-_-a"}))).not.to.throw();
+  });
+
+  it('Prohibits Invalid Question IDs', () => {
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "1question_id"}))).to.throw(Error);
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: ""}))).to.throw(Error);
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "1"}))).to.throw(Error);
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "-_alsdf"}))).to.throw(Error);
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "_sflaalsdf"}))).to.throw(Error);
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "aslkdhf+="}))).to.throw(Error);
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "_______"}))).to.throw(Error);
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "++++"}))).to.throw(Error);
+    expect(() => new Question(CUSTOMIZE(MC_Basic, {id: "0azaz"}))).to.throw(Error);
+  });
+
+});

--- a/test/response/fitb.spec.ts
+++ b/test/response/fitb.spec.ts
@@ -83,7 +83,7 @@ int main() {
 }
 \`\`\`
 `
-  }, "test_fitb", undefined);
+  }, "test_fitb", "test_fitb", undefined);
 
   it('renders markdown in FITB content', () => {
     expect(rendered).to.contain("this is a <strong>test</strong> <em>only</em> a <code>test</code>");

--- a/test/section.spec.ts
+++ b/test/section.spec.ts
@@ -1,0 +1,32 @@
+import 'mocha';
+import { expect } from 'chai';
+import { ExamSubmission, fillManifest } from '../src/submissions';
+import { Question, Section } from '../src/exams';
+import { CUSTOMIZE, QuestionSpecification, SectionSpecification } from '../src/specification';
+import { MC_Basic } from './question.spec';
+import { INVALID_IDS, VALID_IDS } from './common.spec';
+
+export const Section_MC_Basic : SectionSpecification = {
+  id: "section_id",
+  title: "[section title]",
+  mk_description: "[description]",
+  questions: [MC_Basic]
+};
+
+
+
+describe('Section Specification', () => {
+
+  it('Allows Valid Section IDs', () => {
+    VALID_IDS.forEach(
+      id => expect(() => new Section(CUSTOMIZE(Section_MC_Basic, {id: id}))).not.to.throw()
+    );
+  });
+
+  it('Prohibits Invalid Section IDs', () => {
+    INVALID_IDS.forEach(
+      id => expect(() => new Section(CUSTOMIZE(Section_MC_Basic, {id: id}))).to.throw()
+    );
+  });
+
+});


### PR DESCRIPTION
This PR adds assertions to verify that IDs that may be used in creating non-hashed UUIDS follow the pattern:

`/^[a-zA-Z][a-zA-Z0-9_\-]*$/`

This includes question, section, and exam IDs as well as student uniqnames.

It also adds corresponding regression tests to ensure valid IDs are accepted and invalid IDs are rejected.