### PR TITLE
Allow rendering blank solutions

### DIFF
--- a/src/response/code_editor.ts
+++ b/src/response/code_editor.ts
@@ -138,7 +138,11 @@ function CODE_EDITOR_RENDERER(response: CodeEditorSpecification, question_id: st
   `;
 }
 
-function CODE_EDITOR_SOLUTION_RENDERER(response: CodeEditorSpecification, solution: ViableSubmission<CodeEditorSubmission>, question_id: string, question_uuid: string, skin?: ExamComponentSkin) {
+function CODE_EDITOR_SOLUTION_RENDERER(response: CodeEditorSpecification, solution: CodeEditorSubmission, question_id: string, question_uuid: string, skin?: ExamComponentSkin) {
+  if (solution === BLANK_SUBMISSION) {
+    solution = "";
+  }
+  
   return `
     <div class="examma-ray-code-editor-header">
       ${response.header ? `<pre><code>${highlightCode(applySkin(response.header, skin), response.code_language)}</code></pre>` : ""}

--- a/src/response/fitb-drop.ts
+++ b/src/response/fitb-drop.ts
@@ -96,7 +96,8 @@ function FITB_DROP_RENDERER(response: FITBDropSpecification, question_id: string
   // TODO: should the skin actually be applied before passing to createFilledFITBDrop? Shouldn't it already apply in that function  ?
 }
 
-function FITB_DROP_SOLUTION_RENDERER(response: FITBDropSpecification, solution: ViableSubmission<FITBDropSubmission>, question_id: string, question_uuid: string, skin?: ExamComponentSkin) {
+function FITB_DROP_SOLUTION_RENDERER(response: FITBDropSpecification, solution: FITBDropSubmission, question_id: string, question_uuid: string, skin?: ExamComponentSkin) {
+
   let group_id = response.group_id ?? question_id;
   return createFilledFITBDrop(applySkin(response.content, skin), response.droppables, group_id, skin, solution);
 

--- a/src/response/fitb.ts
+++ b/src/response/fitb.ts
@@ -154,8 +154,11 @@ function FITB_RENDERER(response: FITBSpecification, question_id: string, questio
   return createFilledFITB(applySkin(response.content, skin));
 }
 
-function FITB_SOLUTION_RENDERER(response: FITBSpecification, solution: ViableSubmission<FITBSubmission>, question_id: string, question_uuid: string, skin?: ExamComponentSkin) {
-  return createFilledFITB(applySkin(response.content, skin), solution.map(s => applySkin(s, skin)));
+function FITB_SOLUTION_RENDERER(response: FITBSpecification, solution: FITBSubmission, question_id: string, question_uuid: string, skin?: ExamComponentSkin) {
+  if (solution !== BLANK_SUBMISSION) {
+    solution = solution.map(s => applySkin(s, skin))
+  }
+  return createFilledFITB(applySkin(response.content, skin), solution);
 }
 
 function FITB_EXTRACTOR(responseElem: JQuery) {

--- a/src/response/mc.ts
+++ b/src/response/mc.ts
@@ -160,10 +160,23 @@ function MC_RENDERER(response: MCSpecification, question_id: string, question_uu
   `;
 }
 
-function MC_SOLUTION_RENDERER(response: MCSpecification, solution: ViableSubmission<MCSubmission>, question_id: string, question_uuid: string, skin?: ExamComponentSkin) {
+function MC_SOLUTION_RENDERER(response: MCSpecification, orig_solution: MCSubmission, question_id: string, question_uuid: string, skin?: ExamComponentSkin) {
+  
+  const was_invalid = orig_solution === INVALID_SUBMISSION;
+
+  if (orig_solution === BLANK_SUBMISSION || orig_solution === INVALID_SUBMISSION) {
+    orig_solution = [];
+  }
+
+  const solution = orig_solution; // Allow type inference within the map() below
 
   return `
-    ${solution.length === 0 ? "The correct solution is to leave all options unselected." : ""}
+    ${was_invalid
+      ? "<p>This solution was invalid (i.e. was outside the space of allowed answer choices - this should not normally happen).</p>"
+      : solution.length === 0
+        ? "<p>All options left unselected.</p>"
+        : ""
+    }
     <form>
     ${(response.multiple && response.limit !== undefined) ? `<div><span class="examma-ray-mc-num-selected">${solution.length}</span> out of ${response.limit} allowed choices are selected.</div>`: ""}
     ${response.choices.map((item,i) => `

--- a/src/response/responses.ts
+++ b/src/response/responses.ts
@@ -29,13 +29,19 @@ export type SubmissionType<QT extends ResponseKind> =
  * are e.g. valid to specify as a sample solution.
  */
 export type ViableSubmission<ST> = Exclude<ST, typeof BLANK_SUBMISSION | typeof INVALID_SUBMISSION>;
+
+/**
+ * A helper type that gives the type representing viable submissions for a given
+ * response kind.
+ */
 export type ViableSubmissionType<QT extends ResponseKind> = ViableSubmission<SubmissionType<QT>>;
+
 
 export type ResponseHandler<QT extends ResponseKind> = {
   parse: (rawSubmission: string | null | undefined) => SubmissionType<QT> | typeof MALFORMED_SUBMISSION,
   validate?: (response: ResponseSpecification<QT>, submission: SubmissionType<QT>) => SubmissionType<QT>,
   render: (response: ResponseSpecification<QT>, question_id: string, question_uuid: string, skin?: ExamComponentSkin) => string,
-  render_sample_solution: (response: ResponseSpecification<QT>, solution: ViableSubmissionType<QT>, question_id: string, question_uuid: string, skin?: ExamComponentSkin) => string,
+  render_sample_solution: (response: ResponseSpecification<QT>, solution: SubmissionType<QT>, question_id: string, question_uuid: string, skin?: ExamComponentSkin) => string,
   activate?: (responseElem: JQuery, is_sample_solution: boolean) => void,
   extract: (responseElem: JQuery) => SubmissionType<QT>,
   fill: (elem: JQuery, submission: SubmissionType<QT>) => void
@@ -64,7 +70,7 @@ export function render_response<QT extends ResponseKind>(response: ResponseSpeci
   return (<ResponseHandler<QT>><unknown>RESPONSE_HANDLERS[<QT>response.kind]).render(response, question_id, question_uuid, skin);
 }
 
-export function render_solution<QT extends ResponseKind>(response: ResponseSpecification<QT>, solution: ViableSubmissionType<QT>, question_id: string, question_uuid: string, skin?: ExamComponentSkin) : string {
+export function render_solution<QT extends ResponseKind>(response: ResponseSpecification<QT>, solution: SubmissionType<QT>, question_id: string, question_uuid: string, skin?: ExamComponentSkin) : string {
   return (<ResponseHandler<QT>><unknown>RESPONSE_HANDLERS[<QT>response.kind]).render_sample_solution(response, solution, question_id, question_uuid, skin);
 }
 

--- a/src/response/select_lines.ts
+++ b/src/response/select_lines.ts
@@ -225,7 +225,14 @@ function renderSLItem(item: SLItem, question_id: string, item_index: number, cod
     </div>`;
 }
 
-function SL_SOLUTION_RENDERER(response: SLSpecification, solution: ViableSubmission<SLSubmission>, question_id: string, question_uuid: string, skin?: ExamComponentSkin) {
+function SL_SOLUTION_RENDERER(response: SLSpecification, orig_solution: SLSubmission, question_id: string, question_uuid: string, skin?: ExamComponentSkin) {
+  
+  if (orig_solution === BLANK_SUBMISSION) {
+    orig_solution = [];
+  }
+
+  const solution = orig_solution; // Allow type inference within the map() below
+  
   let item_index = 0;
   return `
     <div style="text-align: right; margin-bottom: 5px;">


### PR DESCRIPTION
This PR relaxes the type on the solution passed to `render_solution` so that it may accept non-viable solutions. This is necessary so that the solution rendering process may be used to render student-submitted solutions as well as sample solutions.

![image](https://user-images.githubusercontent.com/14828215/155902384-53306f1c-1f17-4de3-9a5d-d80a386dc7df.png)

All existing response elements are updated to render non-viable solutions accordingly.

Additionally, the `render_sample_solution` function is renamed to `render_solution` to reflect the fact it may be used to render solutions of any kind. Note that the `sample_solution` given in a response element specification must still be viable.